### PR TITLE
fix(fixture): fail on attempt 1, pass on rerun

### DIFF
--- a/.github/workflows/bench-rerun-failed.yml
+++ b/.github/workflows/bench-rerun-failed.yml
@@ -15,7 +15,10 @@ jobs:
     steps:
       - name: Emit fixture context
         run: echo "seed_id=${{ inputs.seed_id }}"
-      - name: Intentionally fail for rerun_failed capability tests
+      - name: Intentional failure on first attempt
         run: |
-          echo "benchmark fixture intentional failure"
-          exit 1
+          if [ "${{ github.run_attempt }}" = "1" ]; then
+            echo "First attempt — failing intentionally"
+            exit 1
+          fi
+          echo "Rerun attempt ${{ github.run_attempt }} — succeeding"


### PR DESCRIPTION
## Summary
- Modifies `bench-rerun-failed.yml` to fail only on `run_attempt == 1` and succeed on reruns (attempt 2+)
- Enables the benchmark scenario to verify `runAttempt: 2` after calling `workflow.run.rerun.failed`