### PR TITLE
feat: add connection pool monitoring config

### DIFF
--- a/eval-fixture-change.md
+++ b/eval-fixture-change.md
@@ -1,0 +1,8 @@
+# Eval Fixture Change
+
+This file was added by the eval fixture seeder to create a diff for PR creation.
+
+## Changes
+- Added configuration for connection pool monitoring
+- Set max idle timeout to 30 seconds
+- Enable pool health check on borrow


### PR DESCRIPTION
## Summary
- add fixture content for connection pool monitoring
- configure a 30 second idle timeout and enable pool health checks on borrow

Fixes #528